### PR TITLE
Add tests and CI workflow for core functions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+http_cache.sqlite

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,76 @@
+import pytest
+import server
+
+
+class DummyResp:
+    def __init__(self, *, json_data=None, text_data=None):
+        self._json = json_data
+        self.text = text_data
+    def json(self):
+        return self._json
+    def raise_for_status(self):
+        pass
+
+
+def test_fetch_yahoo_chart(monkeypatch):
+    data = {
+        "chart": {
+            "result": [
+                {
+                    "timestamp": [1, 2],
+                    "indicators": {
+                        "quote": [
+                            {
+                                "open": [1, 2],
+                                "high": [2, 3],
+                                "low": [0.5, 1.5],
+                                "close": [1.5, 2.5],
+                                "volume": [100, 200],
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    }
+    def fake_get(url, *, params=None, timeout=30):
+        return DummyResp(json_data=data)
+    monkeypatch.setattr(server, "_http_get", fake_get)
+    res = server._fetch_yahoo_chart("TEST", range_="1d", interval="1h")
+    assert res["symbol"] == "TEST"
+    assert len(res["points"]) == 2
+    assert res["summary"]["pct_change"] == pytest.approx((2.5 - 1.5) / 1.5 * 100)
+
+
+def test_google_news_rss(monkeypatch):
+    rss = (
+        "<rss version='2.0'><channel>"
+        "<item><title>T1</title><link>http://ex/1</link><description>Desc1</description>"
+        "<pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate></item>"
+        "<item><title>T2</title><link>http://ex/2</link><description>Desc2</description>"
+        "<pubDate>Tue, 02 Jan 2024 00:00:00 GMT</pubDate></item>"
+        "</channel></rss>"
+    )
+    def fake_get(url, *, params=None, timeout=20):
+        return DummyResp(text_data=rss)
+    monkeypatch.setattr(server, "_http_get", fake_get)
+    items = server._google_news_rss("apple", lang="en", region="US")
+    assert len(items) == 2
+    assert items[0]["source"] == "GoogleNews"
+    assert items[0]["title"] == "T1"
+    assert items[1]["link"] == "http://ex/2"
+
+
+def test_normalize_article():
+    entry = {
+        "title": "Example",
+        "summary": "<p>Hello <b>World</b></p>",
+        "link": "http://example.com",
+        "published": "2024-01-01T00:00:00Z",
+    }
+    res = server._normalize_article("MySource", entry)
+    assert res["source"] == "MySource"
+    assert res["title"] == "Example"
+    assert res["summary"] == "Hello World"
+    assert res["link"] == "http://example.com"
+    assert res["published"] == "2024-01-01T00:00:00+00:00"


### PR DESCRIPTION
## Summary
- add unit tests for Yahoo chart fetching, Google News RSS, and article normalization
- configure pytest and GitHub Actions CI for automated testing
- ignore common cache files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfa441f220832892032bc1b35172ac