### PR TITLE
Add financial data tools for options, FRED and DART filings

### DIFF
--- a/finance_news/__init__.py
+++ b/finance_news/__init__.py
@@ -11,6 +11,8 @@ from .data_sources import (
     _google_news_rss,
     _normalize_article,
     _news_all,
+    _fred_fetch,
+    _dart_filings,
 )
 from .tools import app
 
@@ -27,4 +29,6 @@ __all__ = [
     "_google_news_rss",
     "_normalize_article",
     "_news_all",
+    "_fred_fetch",
+    "_dart_filings",
 ]

--- a/server.py
+++ b/server.py
@@ -4,7 +4,14 @@ from typing import Any, Dict, List, Optional
 import feedparser
 from dateutil import parser as dateparser
 
-from finance_news import app, _http_get, _normalize_article
+from finance_news import (
+    app,
+    _http_get,
+    _normalize_article,
+    _yahoo_options_chain,
+    _fred_fetch,
+    _dart_filings,
+)
 
 
 def _fetch_yahoo_chart(symbol: str, range_: str = "1mo", interval: str = "1d") -> Dict[str, Any]:
@@ -63,7 +70,16 @@ def _google_news_rss(query: str, lang: str = "ko", region: str = "KR") -> List[D
     return out
 
 
-__all__ = ["app", "_http_get", "_fetch_yahoo_chart", "_google_news_rss", "_normalize_article"]
+__all__ = [
+    "app",
+    "_http_get",
+    "_fetch_yahoo_chart",
+    "_google_news_rss",
+    "_normalize_article",
+    "_yahoo_options_chain",
+    "_fred_fetch",
+    "_dart_filings",
+]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose Yahoo options chain, FRED series, and DART filings as MCP tools
- export new data helpers from package and server
- add tests for new financial data utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b0afbd6c832887506c1b70987bbb