### PR TITLE
Add web UI for news summaries and market analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ MCP server exposing finance/news tools: RSS aggregation, Yahoo Finance charts, F
 ### Web UI (optional)
 - Start the web server:
   ```powershell
-  python web/app.py
+  python web/app.py  # or: python -m web.app
   ```
 - Open http://127.0.0.1:8000 in your browser.
 - Click preset buttons (코스피, 코스닥, 글로벌) for quick summaries, or use the category + keyword search to analyze a specific market (e.g., 커피/환율/삼성전자).
+- **Troubleshooting**: If you encounter `ModuleNotFoundError: finance_news`, ensure you're running from the repository root or use `python -m web.app`.
 
 Notes:
 - The server uses retries and short-lived caching (requests-cache, ~180s) for resilience.

--- a/finance_news/__init__.py
+++ b/finance_news/__init__.py
@@ -11,6 +11,8 @@ from .data_sources import (
     _google_news_rss,
     _normalize_article,
     _news_all,
+    _fred_fetch,
+    _dart_filings,
 )
 from .tools import app
 
@@ -27,4 +29,6 @@ __all__ = [
     "_google_news_rss",
     "_normalize_article",
     "_news_all",
+    "_fred_fetch",
+    "_dart_filings",
 ]

--- a/finance_news/data_sources.py
+++ b/finance_news/data_sources.py
@@ -162,7 +162,11 @@ def _normalize_article(source_name: str, entry: dict) -> dict:
 
 def _google_news_rss(query: str, lang: str = "ko", region: str = "KR") -> List[dict]:
     url = f"https://news.google.com/rss/search?q={query}&hl={lang}&gl={region}&ceid={region}:{lang}"
-    feed = feedparser.parse(url)
+    try:
+        r = _http_get(url, timeout=20)
+        feed = feedparser.parse(r.text)
+    except Exception:
+        return []
     out: List[dict] = []
     for e in feed.entries:
         out.append(_normalize_article("Google News", e))

--- a/server.py
+++ b/server.py
@@ -4,7 +4,14 @@ from typing import Any, Dict, List, Optional
 import feedparser
 from dateutil import parser as dateparser
 
-from finance_news import app, _http_get, _normalize_article
+from finance_news import (
+    app,
+    _http_get,
+    _normalize_article,
+    _yahoo_options_chain,
+    _fred_fetch,
+    _dart_filings,
+)
 
 
 def _fetch_yahoo_chart(symbol: str, range_: str = "1mo", interval: str = "1d") -> Dict[str, Any]:
@@ -63,7 +70,16 @@ def _google_news_rss(query: str, lang: str = "ko", region: str = "KR") -> List[D
     return out
 
 
-__all__ = ["app", "_http_get", "_fetch_yahoo_chart", "_google_news_rss", "_normalize_article"]
+__all__ = [
+    "app",
+    "_http_get",
+    "_fetch_yahoo_chart",
+    "_google_news_rss",
+    "_normalize_article",
+    "_yahoo_options_chain",
+    "_fred_fetch",
+    "_dart_filings",
+]
 
 
 if __name__ == "__main__":

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,53 @@
+from fastapi.testclient import TestClient
+import web.app as webapp
+import subprocess
+import sys
+import time
+
+
+def test_preset_kospi(monkeypatch):
+    def fake_news(query, lang="ko", region="KR"):
+        assert query == "코스피"
+        return [{"title": "t"}]
+    monkeypatch.setattr(webapp, "_google_news_rss", fake_news)
+    client = TestClient(webapp.app)
+    resp = client.get("/preset/kospi")
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["title"] == "t"
+
+
+def test_preset_global(monkeypatch):
+    def fake_all():
+        return [{"title": "g"}]
+    monkeypatch.setattr(webapp, "_news_all", fake_all)
+    client = TestClient(webapp.app)
+    resp = client.get("/preset/global")
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["title"] == "g"
+
+
+def test_analyze(monkeypatch):
+    def fake_chart(symbol, range_="1mo", interval="1d"):
+        return {"symbol": symbol}
+    def fake_news(query, lang="ko", region="KR"):
+        return [{"title": "n"}]
+    monkeypatch.setattr(webapp, "_fetch_yahoo_chart", fake_chart)
+    monkeypatch.setattr(webapp, "_google_news_rss", fake_news)
+    client = TestClient(webapp.app)
+    resp = client.get("/analyze", params={"category": "index", "keyword": "코스피"})
+    data = resp.json()
+    assert data["symbol"] == "^KS11"
+    assert data["chart"]["symbol"] == "^KS11"
+    assert data["news"][0]["title"] == "n"
+
+
+def test_app_script_starts_without_import_error():
+    proc = subprocess.Popen([sys.executable, "web/app.py"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        time.sleep(1)
+        proc.terminate()
+        stdout, stderr = proc.communicate(timeout=3)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+    assert b"ModuleNotFoundError" not in stderr

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import os
+import sys
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+
+# allow running `python web/app.py` without PYTHONPATH tweaks
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from finance_news import (
+    _fetch_yahoo_chart,
+    _google_news_rss,
+    _news_all,
+    COMMODITY_MAP,
+    FX_ALIAS,
+    INDEX_MAP,
+    EQUITY_MAP,
+)
+from finance_news.data_sources import _normalize_kw
+
+app = FastAPI(title="Financial News Web")
+
+
+def _resolve_symbol(category: str, keyword: str) -> Optional[str]:
+    maps = {
+        "commodity": COMMODITY_MAP,
+        "fx": FX_ALIAS,
+        "index": INDEX_MAP,
+        "equity": EQUITY_MAP,
+    }
+    m = maps.get(category.lower())
+    if not m:
+        return None
+    return m.get(_normalize_kw(keyword))
+
+
+@app.get("/", response_class=HTMLResponse)
+def home() -> str:
+    return (
+        "<html><body><h1>Financial News</h1>"
+        "<form action='/analyze' method='get'>"
+        "<select name='category'>"
+        "<option value='index'>지수</option>"
+        "<option value='fx'>환율</option>"
+        "<option value='commodity'>원자재</option>"
+        "<option value='equity'>주식</option>"
+        "</select>"
+        "<input type='text' name='keyword' placeholder='Keyword'>"
+        "<button type='submit'>Search</button>"
+        "</form>"
+        "<p>Quick Summaries:</p>"
+        "<ul>"
+        "<li><a href='/preset/kospi'>코스피</a></li>"
+        "<li><a href='/preset/kosdaq'>코스닥</a></li>"
+        "<li><a href='/preset/global'>글로벌</a></li>"
+        "</ul>"
+        "</body></html>"
+    )
+
+
+@app.get("/preset/{name}")
+def preset(name: str, limit: int = 10) -> dict:
+    n = name.lower()
+    if n == "kospi":
+        items = _google_news_rss("코스피")[:limit]
+    elif n == "kosdaq":
+        items = _google_news_rss("코스닥")[:limit]
+    elif n == "global":
+        items = _news_all()[:limit]
+    else:
+        raise HTTPException(status_code=404, detail="unknown_preset")
+    return {"items": items}
+
+
+@app.get("/analyze")
+def analyze(category: str, keyword: str, limit: int = 10) -> dict:
+    symbol = _resolve_symbol(category, keyword)
+    chart = _fetch_yahoo_chart(symbol) if symbol else None
+    news = _google_news_rss(keyword)[:limit]
+    return {"symbol": symbol, "chart": chart, "news": news}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=8000)


### PR DESCRIPTION
## Summary
- add FastAPI-based web interface with preset market summaries and category+keyword analysis
- fetch Google News feeds using cached session for retryable HTTP requests
- cover new endpoints with tests
- allow launching web app as script by appending project root to `sys.path`
- document `web/app.py` usage and add subprocess test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b0afbd6c832887506c1b70987bbb