### PR TITLE
Fix manifest schema for Claude Desktop

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,14 @@
   "name": "financial_news_tool",
   "description": "Provides access to financial market data including news, stock prices, economic indicators, and corporate filings.",
   "version": "1.0.0",
-  "author": "hashyun",
-  "server": {
-    "command": "python",
-    "args": ["server.py"]
-  }
+  "author": {
+    "name": "hashyun"
+  },
+  "servers": [
+    {
+      "transport": "stdio",
+      "command": "python",
+      "args": ["server.py"]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- update the manifest to use the new Claude Desktop schema for authors and servers
- include stdio transport configuration for the MCP server entry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4d148b5688328a0ecaad377108316