### PR TITLE
Fix Claude config snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ The project intentionally ships **without** any HTTP web application.  All inter
    ```json
    {
      "mcpServers": {
-       {
-         "name": "finance-news",
+       "finance-news": {
          "command": "python",
          "args": ["/absolute/path/to/server.py"],
          "description": "Secure finance news and market data tools"


### PR DESCRIPTION
## Summary
- correct the Claude Desktop configuration example so the MCP server entry is under the proper key

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4d5576978832889f657c1e8dd4a73